### PR TITLE
Disable cppcheck

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        linter: [cppcheck, cpplint, uncrustify, xmllint]
+        # We exclude cppcheck due to https://github.com/ament/ament_lint/pull/345
+        linter: [cpplint, uncrustify, xmllint]
     steps:
       - uses: actions/checkout@v3.3.0
       - uses: ros-tooling/setup-ros@0.5.0

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ ament_lint_cpp:
   runs-on: ubuntu-latest
   strategy:
     # We want all linters to run even if one fails
-    fail-fast: false 
+    fail-fast: false
     matrix:
       linter: [cppcheck, cpplint, uncrustify]
     steps:


### PR DESCRIPTION
People can enable it by including it in the list and defining an environment variable. See https://github.com/ament/ament_lint/pull/345

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>